### PR TITLE
JWT 토큰 만료 예외처리 필터 추가 / 전역 예외처리 예외 타입 수정 (ApiRequestException 추가) #32 #40

### DIFF
--- a/src/main/java/com/udangtangtang/backend/config/WebSecurityConfig.java
+++ b/src/main/java/com/udangtangtang/backend/config/WebSecurityConfig.java
@@ -1,7 +1,8 @@
 package com.udangtangtang.backend.config;
 
-import com.udangtangtang.backend.controller.JwtAuthenticationEntryPoint;
-import com.udangtangtang.backend.controller.JwtAuthenticationFilter;
+import com.udangtangtang.backend.filter.JwtAuthenticationEntryPoint;
+import com.udangtangtang.backend.filter.JwtAuthenticationFilter;
+import com.udangtangtang.backend.filter.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,7 +26,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-    private final JwtAuthenticationFilter jwtRequestFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -38,12 +40,16 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/login/kakao").permitAll()
                 .antMatchers("/signup").permitAll()
                 .antMatchers("/").permitAll()
+
+                .mvcMatchers(HttpMethod.GET, "/articles").permitAll()
                 .mvcMatchers(HttpMethod.GET, "/articles/**").permitAll()
                 .mvcMatchers(HttpMethod.GET, "/likes/guest/**").permitAll()
                 .mvcMatchers(HttpMethod.GET, "/comment/**").permitAll()
+                .mvcMatchers(HttpMethod.GET, "/profile/navbar-image/**").permitAll()
                 .anyRequest().authenticated().and()
                 .cors().and()
-                .exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint).and().sessionManagement()
+                .exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint).and()
+                .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
                 .formLogin()
                 .loginPage("/user/login")
@@ -53,8 +59,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .logout();
 
-
-        http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
     }
 
     @Bean

--- a/src/main/java/com/udangtangtang/backend/controller/ArticleController.java
+++ b/src/main/java/com/udangtangtang/backend/controller/ArticleController.java
@@ -47,8 +47,8 @@ public class ArticleController {
                               @RequestParam("location") String locationJsonString,
                               @RequestParam("tagNames") List<String> tagNames,
                               @Nullable @RequestParam("imageFiles") List<MultipartFile> imageFiles,
-                              @Nullable @RequestParam("rmImageIdList") List<Long> rmImageIdList) {
-        articleService.updateArticle(userDetails.getUser(), id, text, new LocationRequestDto(locationJsonString), tagNames, imageFiles, rmImageIdList);
+                              @Nullable @RequestParam("rmImageIdList") List<Long> rmImageIds) {
+        articleService.updateArticle(userDetails.getUser(), id, text, new LocationRequestDto(locationJsonString), tagNames, imageFiles, rmImageIds);
     }
 
     @DeleteMapping("/articles/{id}")

--- a/src/main/java/com/udangtangtang/backend/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/udangtangtang/backend/exception/ApiExceptionHandler.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
-    @ExceptionHandler(value = { IllegalArgumentException.class, NullPointerException.class, UsernameNotFoundException.class })
+    @ExceptionHandler(value = { ApiRequestException.class })
     public ResponseEntity<Object> handleApiRequestException(Exception ex) {
         ApiException apiException = new ApiException(
                 ex.getMessage(),
@@ -20,46 +20,4 @@ public class ApiExceptionHandler {
                 HttpStatus.BAD_REQUEST
         );
     }
-
-    /* FIXME] 각각의 예외에 따라 다른 처리가 필요하다면, 아래와 같이 예외 별로 핸들러를 개별적으로 생성해주세요. */
-    /*
-    @ExceptionHandler(value = { IllegalArgumentException.class })
-    public ResponseEntity<Object> handleApiRequestException(IllegalArgumentException ex) {
-        ApiException apiException = new ApiException(
-                ex.getMessage(),
-                HttpStatus.BAD_REQUEST
-        );
-
-        return new ResponseEntity<>(
-                apiException,
-                HttpStatus.BAD_REQUEST
-        );
-    }
-
-    @ExceptionHandler(value = { NullPointerException.class })
-    public ResponseEntity<Object> handleNullPointerException(NullPointerException ex) {
-        ApiException apiException = new ApiException(
-                ex.getMessage(),
-                HttpStatus.BAD_REQUEST
-        );
-
-        return new ResponseEntity<>(
-                apiException,
-                HttpStatus.BAD_REQUEST
-        );
-    }
-
-    @ExceptionHandler(value = { UsernameNotFoundException.class })
-    public ResponseEntity<Object> handleNullPointerException(UsernameNotFoundException ex) {
-        ApiException apiException = new ApiException(
-                ex.getMessage(),
-                HttpStatus.BAD_REQUEST
-        );
-
-        return new ResponseEntity<>(
-                apiException,
-                HttpStatus.BAD_REQUEST
-        );
-    }
-    */
 }

--- a/src/main/java/com/udangtangtang/backend/exception/ApiRequestException.java
+++ b/src/main/java/com/udangtangtang/backend/exception/ApiRequestException.java
@@ -1,0 +1,11 @@
+package com.udangtangtang.backend.exception;
+
+public class ApiRequestException extends IllegalArgumentException {
+    public ApiRequestException(String message) {
+        super(message);
+    }
+
+    public ApiRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/udangtangtang/backend/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/udangtangtang/backend/filter/JwtAuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-package com.udangtangtang.backend.controller;
+package com.udangtangtang.backend.filter;
 
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;

--- a/src/main/java/com/udangtangtang/backend/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/udangtangtang/backend/filter/JwtAuthenticationFilter.java
@@ -1,9 +1,11 @@
-package com.udangtangtang.backend.controller;
+package com.udangtangtang.backend.filter;
 
 import com.udangtangtang.backend.util.JwtTokenUtil;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.SignatureException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -41,10 +43,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 username = jwtTokenUtil.getUsernameFromToken(authToken);
             } catch (IllegalArgumentException e) {
                 logger.error("an error occured during getting username from token", e);
+                throw new JwtException("유효하지 않은 토큰");
             } catch (ExpiredJwtException e) {
                 logger.warn("the token is expired and not valid anymore", e);
+                throw new JwtException("유효하지 않은 토큰");
             } catch(SignatureException e){
                 logger.error("Authentication Failed. Username or Password not valid.");
+                throw new JwtException("유효하지 않은 토큰");
             }
         } else {
             logger.warn("couldn't find bearer string, will ignore the header");

--- a/src/main/java/com/udangtangtang/backend/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/udangtangtang/backend/filter/JwtExceptionFilter.java
@@ -1,0 +1,33 @@
+package com.udangtangtang.backend.filter;
+
+import io.jsonwebtoken.JwtException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws ServletException, IOException {
+        try {
+            chain.doFilter(req, res);
+        } catch (JwtException ex) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, res, ex);
+        }
+    }
+
+    public void setErrorResponse(HttpStatus status, HttpServletResponse res, Throwable ex) throws IOException {
+        res.setStatus(status.value());
+        res.setContentType("application/json; charset=UTF-8");
+
+        JwtExceptionResponse jwtExceptionResponse = new JwtExceptionResponse(ex.getMessage(), HttpStatus.UNAUTHORIZED);
+        res.getWriter().write(jwtExceptionResponse.convertToJson());
+    }
+}

--- a/src/main/java/com/udangtangtang/backend/filter/JwtExceptionResponse.java
+++ b/src/main/java/com/udangtangtang/backend/filter/JwtExceptionResponse.java
@@ -1,0 +1,21 @@
+package com.udangtangtang.backend.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class JwtExceptionResponse {
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public String convertToJson() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+}

--- a/src/main/java/com/udangtangtang/backend/service/ArticleService.java
+++ b/src/main/java/com/udangtangtang/backend/service/ArticleService.java
@@ -2,6 +2,7 @@ package com.udangtangtang.backend.service;
 
 import com.udangtangtang.backend.domain.*;
 import com.udangtangtang.backend.dto.LocationRequestDto;
+import com.udangtangtang.backend.exception.ApiRequestException;
 import com.udangtangtang.backend.repository.*;
 import com.udangtangtang.backend.util.LocationDataPreprocess;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,7 @@ public class ArticleService {
 
     public Article getArticle(Long id) {
         return articleRepository.findById(id).orElseThrow(
-                () -> new NullPointerException(String.format("해당되는 아이디(%d)의 게시물이 없습니다.", id))
+                () -> new ApiRequestException(String.format("해당되는 아이디(%d)의 게시물이 없습니다.", id))
         );
     }
 
@@ -55,19 +56,21 @@ public class ArticleService {
     }
 
     @Transactional
-    public Article updateArticle(User user, Long id, String text, LocationRequestDto locationRequestDto, List<String> tagNames, List<MultipartFile> imageFiles, List<Long> rmImageIdList) {
+    public Article updateArticle(User user, Long id, String text, LocationRequestDto locationRequestDto, List<String> tagNames, List<MultipartFile> imageFiles, List<Long> rmImageIds) {
         Article article = articleRepository.findById(id).orElseThrow(
-                () -> new NullPointerException(String.format("해당되는 아이디(%d)의 게시물이 없습니다.", id))
+                () -> new ApiRequestException(String.format("해당되는 아이디(%d)의 게시물이 없습니다.", id))
         );
 
         // 기존에 저장된 이미지 삭제
-        for(Long imageId : rmImageIdList) {
-            Image image = imageRepository.findById(imageId).orElseThrow(
-                    () -> new NullPointerException(String.format("해당되는 아이디(%d)의 이미지가 없습니다.", imageId))
-            );
-            fileProcessService.deleteImage(image.getUrl());
+        if(rmImageIds != null) {
+            for (Long imageId : rmImageIds) {
+                Image image = imageRepository.findById(imageId).orElseThrow(
+                        () -> new ApiRequestException(String.format("해당되는 아이디(%d)의 이미지가 없습니다.", imageId))
+                );
+                fileProcessService.deleteImage(image.getUrl());
+            }
+            imageRepository.deleteAllById(rmImageIds);
         }
-        imageRepository.deleteAllById(rmImageIdList);
 
         locationDataPreprocess.categoryNamePreprocess(locationRequestDto);
         Location location = locationRepository.save(new Location(locationRequestDto, user.getId()));
@@ -90,9 +93,9 @@ public class ArticleService {
     }
 
     @Transactional
-    public void deleteArticle(Long id) throws IllegalArgumentException {
+    public void deleteArticle(Long id) {
         Article article = articleRepository.findById(id).orElseThrow(
-                () -> new NullPointerException(String.format("아이디(%d)에 해당되는 게시물이 없습니다.", id))
+                () -> new ApiRequestException(String.format("아이디(%d)에 해당되는 게시물이 없습니다.", id))
         );
 
         // S3에 업로드된 이미지 삭제

--- a/src/main/java/com/udangtangtang/backend/service/CommentService.java
+++ b/src/main/java/com/udangtangtang/backend/service/CommentService.java
@@ -5,6 +5,7 @@ import com.udangtangtang.backend.domain.Comment;
 import com.udangtangtang.backend.domain.User;
 import com.udangtangtang.backend.dto.CommentRequestDto;
 import com.udangtangtang.backend.dto.CommentResponseDto;
+import com.udangtangtang.backend.exception.ApiRequestException;
 import com.udangtangtang.backend.repository.ArticleRepository;
 import com.udangtangtang.backend.repository.CommentRepository;
 import com.udangtangtang.backend.repository.UserRepository;
@@ -42,9 +43,9 @@ public class CommentService {
 
     public void saveComment(Long userId, Long articleId, CommentRequestDto commentRequestDto) {
         Article article = articleRepository.findById(articleId).orElseThrow(
-                () -> new NullPointerException("해당 게시글이 존재하지 않습니다."));
+                () -> new ApiRequestException("해당 게시글이 존재하지 않습니다."));
         User user = userRepository.findById(userId).orElseThrow(
-                () -> new NullPointerException("해당 유저가 존재하지 않습니다."));
+                () -> new ApiRequestException("해당 유저가 존재하지 않습니다."));
         Comment comment = new Comment(user, article, commentRequestDto.getCommentText());
         commentRepository.save(comment);
     }

--- a/src/main/java/com/udangtangtang/backend/service/FileProcessService.java
+++ b/src/main/java/com/udangtangtang/backend/service/FileProcessService.java
@@ -2,6 +2,7 @@ package com.udangtangtang.backend.service;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.udangtangtang.backend.domain.FileFolder;
+import com.udangtangtang.backend.exception.ApiRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,7 +27,8 @@ public class FileProcessService {
         try (InputStream inputStream = file.getInputStream()) {
             amazonS3Service.uploadFile(inputStream, objectMetadata, fileName);
         } catch (IOException ioe) {
-            throw new IllegalArgumentException(String.format("파일 변환 중 에러가 발생했습니다 (%s)", file.getOriginalFilename()));
+            ioe.printStackTrace();
+            throw new ApiRequestException(String.format("파일 변환 중 에러가 발생했습니다 (%s)", file.getOriginalFilename()));
         }
 
         return amazonS3Service.getFileUrl(fileName);

--- a/src/main/java/com/udangtangtang/backend/service/LikeService.java
+++ b/src/main/java/com/udangtangtang/backend/service/LikeService.java
@@ -3,6 +3,7 @@ package com.udangtangtang.backend.service;
 import com.udangtangtang.backend.domain.Article;
 import com.udangtangtang.backend.domain.Likes;
 import com.udangtangtang.backend.dto.LikeResponseDto;
+import com.udangtangtang.backend.exception.ApiRequestException;
 import com.udangtangtang.backend.repository.ArticleRepository;
 import com.udangtangtang.backend.repository.LikesRepository;
 import com.udangtangtang.backend.repository.UserRepository;
@@ -68,7 +69,7 @@ public class LikeService {
 
     public LikeResponseDto getLike(Long id, Long userId) {
         Article article = articleRepository.findById(id).orElseThrow(
-                () -> new NullPointerException("해당되는 아이디의 게시물이 없습니다.")
+                () -> new ApiRequestException("해당되는 아이디의 게시물이 없습니다.")
         );
         Long likeCount = likesRepository.countByArticleId(id);
 
@@ -83,7 +84,7 @@ public class LikeService {
 
     public LikeResponseDto getLikeGuest(Long id) {
         Article article = articleRepository.findById(id).orElseThrow(
-                () -> new NullPointerException("해당되는 아이디의 게시물이 없습니다.")
+                () -> new ApiRequestException("해당되는 아이디의 게시물이 없습니다.")
         );
         Long likeCount = likesRepository.countByArticleId(id);
         LikeResponseDto likeResponseDto = new LikeResponseDto(article, likeCount, false);
@@ -94,13 +95,13 @@ public class LikeService {
     @Transactional
     public void increaseLikeCount(Long userId, Long articleId) {
         if(likesRepository.findByUserIdAndArticleId(userId, articleId).isPresent()) {
-            throw new IllegalArgumentException("이미 좋아요를 누른 게시글입니다.");
+            throw new ApiRequestException("이미 좋아요를 누른 게시글입니다.");
         }
         userRepository.findById(userId).orElseThrow(
-                () -> new NullPointerException("해당 유저가 존재하지 않습니다!")
+                () -> new ApiRequestException("해당 유저가 존재하지 않습니다!")
         );
         articleRepository.findById(articleId).orElseThrow(
-                () -> new NullPointerException("해당 글이 존재하지 않습니다!")
+                () -> new ApiRequestException("해당 글이 존재하지 않습니다!")
         );
         likesRepository.save(new Likes(userId, articleId));
     }
@@ -108,13 +109,13 @@ public class LikeService {
     @Transactional
     public void decreaseLikeCount(Long user, Long articleId) {
         Likes deleteLike = likesRepository.findByUserIdAndArticleId(user, articleId).orElseThrow(
-                () -> new NullPointerException("해당 좋아요 항목이 존재하지 않습니다!")
+                () -> new ApiRequestException("해당 좋아요 항목이 존재하지 않습니다!")
         );
         userRepository.findById(user).orElseThrow(
-                () -> new NullPointerException("해당 유저가 존재하지 않습니다!")
+                () -> new ApiRequestException("해당 유저가 존재하지 않습니다!")
         );
         articleRepository.findById(articleId).orElseThrow(
-                () -> new NullPointerException("해당 글이 존재하지 않습니다!")
+                () -> new ApiRequestException("해당 글이 존재하지 않습니다!")
         );
         likesRepository.delete(deleteLike);
     }

--- a/src/main/java/com/udangtangtang/backend/service/UserProfileService.java
+++ b/src/main/java/com/udangtangtang/backend/service/UserProfileService.java
@@ -6,6 +6,7 @@ import com.udangtangtang.backend.domain.Article;
 import com.udangtangtang.backend.domain.FileFolder;
 import com.udangtangtang.backend.domain.User;
 import com.udangtangtang.backend.dto.ProfileRequestDto;
+import com.udangtangtang.backend.exception.ApiRequestException;
 import com.udangtangtang.backend.repository.ArticleRepository;
 import com.udangtangtang.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -45,7 +46,7 @@ public class UserProfileService {
     @Transactional
     public String updateProfileImage(Long userId, MultipartFile newProfileImage) {
         User user = userRepository.findById(userId).orElseThrow(
-                () -> new NullPointerException("해당 유저가 존재하지 않습니다!"));
+                () -> new ApiRequestException("해당 유저가 존재하지 않습니다!"));
 
         deleteUserProfileImageFromS3(user);
 
@@ -57,14 +58,14 @@ public class UserProfileService {
 
     public String getUserProfileImageUrl(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(
-                () -> new NullPointerException("해당 유저가 존재하지 않습니다!"));
+                () -> new ApiRequestException("해당 유저가 존재하지 않습니다!"));
         return user.getUserProfileImageUrl();
     }
 
     @Transactional
     public void updateUserPassword(Long userId, ProfileRequestDto profileRequestDto) throws Exception {
         User user = userRepository.findById(userId).orElseThrow(
-                () -> new NullPointerException("해당 유저가 존재하지 않습니다!"));
+                () -> new ApiRequestException("해당 유저가 존재하지 않습니다!"));
         String nowPassword = profileRequestDto.getNowPassword();
         String newPassword = profileRequestDto.getNewPassword();
 
@@ -78,7 +79,7 @@ public class UserProfileService {
     @Transactional
     public String updateUserProfileIntroText(Long userId, ProfileRequestDto profileRequestDto) {
         User user = userRepository.findById(userId).orElseThrow(
-                () -> new NullPointerException("해당 유저가 존재하지 않습니다!"));
+                () -> new ApiRequestException("해당 유저가 존재하지 않습니다!"));
         String userProfileIntro = profileRequestDto.getUserProfileIntro();
         if (!userProfileIntro.equals(user.getUserProfileIntro())) {
             user.setUserProfileIntro(userProfileIntro);
@@ -100,7 +101,7 @@ public class UserProfileService {
     @Transactional
     public void resetUserProfileImage(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(
-                () -> new NullPointerException("해당 유저가 존재하지 않습니다!"));
+                () -> new ApiRequestException("해당 유저가 존재하지 않습니다!"));
 
         deleteUserProfileImageFromS3(user);
 

--- a/src/main/java/com/udangtangtang/backend/service/UserService.java
+++ b/src/main/java/com/udangtangtang/backend/service/UserService.java
@@ -3,6 +3,7 @@ package com.udangtangtang.backend.service;
 import com.udangtangtang.backend.domain.User;
 import com.udangtangtang.backend.domain.UserRole;
 import com.udangtangtang.backend.dto.SignupRequestDto;
+import com.udangtangtang.backend.exception.ApiRequestException;
 import com.udangtangtang.backend.repository.UserRepository;
 import com.udangtangtang.backend.security.kakao.KakaoOAuth2;
 import com.udangtangtang.backend.security.kakao.KakaoUserInfo;
@@ -32,12 +33,12 @@ public class UserService {
         this.authenticationManager = authenticationManager;
     }
 
-    public void registerUser(SignupRequestDto requestDto) {
+    public void registerUser(SignupRequestDto requestDto) throws ApiRequestException {
         String username = requestDto.getUsername();
         // 사용자이름 중복 확인
         Optional<User> found = userRepository.findByUsername(username);
         if (found.isPresent()) {
-            throw new IllegalArgumentException("중복된 사용자 이름이 존재합니다.");
+            throw new ApiRequestException("중복된 사용자 이름이 존재합니다.");
         }
 
         String password = passwordEncoder.encode(requestDto.getPassword());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,13 +20,13 @@ spring:
       ddl-auto: update
     generate-ddl: false
 
-logging:
-  level:
-    org:
-      hibernate:
-        SQL: error # debug
-        type:
-          descriptor:
-            sql: trace
+#logging:
+#  level:
+#    org:
+#      hibernate:
+#        SQL: error # debug
+#        type:
+#          descriptor:
+#            sql: trace
 jwt:
   secret: javainuse

--- a/src/test/java/com/udangtangtang/backend/service/ArticleServiceTest.java
+++ b/src/test/java/com/udangtangtang/backend/service/ArticleServiceTest.java
@@ -4,6 +4,7 @@ import com.udangtangtang.backend.domain.Article;
 import com.udangtangtang.backend.domain.Location;
 import com.udangtangtang.backend.domain.User;
 import com.udangtangtang.backend.dto.LocationRequestDto;
+import com.udangtangtang.backend.exception.ApiRequestException;
 import com.udangtangtang.backend.repository.ArticleRepository;
 import com.udangtangtang.backend.repository.ImageRepository;
 import com.udangtangtang.backend.repository.LocationRepository;
@@ -165,12 +166,12 @@ class ArticleServiceTest {
                 Long undefinedId = 200L;
 
                 when(articleRepository.findById(undefinedId)).thenThrow(
-                        new NullPointerException(String.format("해당되는 아이디(%d)의 게시물이 없습니다.", undefinedId)));
+                        new ApiRequestException(String.format("해당되는 아이디(%d)의 게시물이 없습니다.", undefinedId)));
 
                 String modifiedText = "* 수정된 게시물 내용 *";
 
                 ArticleService articleService = new ArticleService(articleRepository, locationRepository, tagRepository, imageRepository, locationDataPreprocess, fileProcessService);
-                Exception exception = assertThrows(NullPointerException.class, () -> {
+                Exception exception = assertThrows(ApiRequestException.class, () -> {
                     articleService.updateArticle(user, undefinedId, modifiedText, locationRequestDto, tagNames, imageFiles, rmImageIdList);
                 });
 

--- a/src/test/java/com/udangtangtang/backend/service/CommentServiceTest.java
+++ b/src/test/java/com/udangtangtang/backend/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.udangtangtang.backend.service;
 import com.udangtangtang.backend.domain.Article;
 import com.udangtangtang.backend.domain.Comment;
 import com.udangtangtang.backend.domain.User;
+import com.udangtangtang.backend.exception.ApiRequestException;
 import com.udangtangtang.backend.repository.ArticleRepository;
 import com.udangtangtang.backend.repository.CommentRepository;
 import com.udangtangtang.backend.repository.UserRepository;
@@ -33,9 +34,9 @@ public class CommentServiceTest {
     public void 댓글_등록() {
         // given
         Article article = articleRepository.findById(3L).orElseThrow(
-                () -> new NullPointerException("해당 게시글이 존재하지 않습니다."));
+                () -> new ApiRequestException("해당 게시글이 존재하지 않습니다."));
         User user = userRepository.findById(1L).orElseThrow(
-                () -> new NullPointerException("해당 유저가 존재하지 않습니다."));
+                () -> new ApiRequestException("해당 유저가 존재하지 않습니다."));
         Comment comment = new Comment(user, article, "test 댓글입니다.");
 
         // when
@@ -43,16 +44,16 @@ public class CommentServiceTest {
 
         // then
         assertEquals(comment, commentRepository.findById(comment.getId()).orElseThrow(
-                () -> new NullPointerException("해당 댓글이 존재하지 않습니다.")));
+                () -> new ApiRequestException("해당 댓글이 존재하지 않습니다.")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = ApiRequestException.class)
     public void 댓글_삭제() {
         // given
         Article article = articleRepository.findById(3L).orElseThrow(
-                () -> new NullPointerException("해당 게시글이 존재하지 않습니다."));
+                () -> new ApiRequestException("해당 게시글이 존재하지 않습니다."));
         User user = userRepository.findById(1L).orElseThrow(
-                () -> new NullPointerException("해당 유저가 존재하지 않습니다."));
+                () -> new ApiRequestException("해당 유저가 존재하지 않습니다."));
         Comment comment = new Comment(user, article, "test 댓글입니다.");
         commentRepository.save(comment);
         Long commentId = comment.getId();
@@ -62,6 +63,6 @@ public class CommentServiceTest {
 
         // then
         commentRepository.findById(commentId).orElseThrow(
-                () -> new NullPointerException("해당 댓글이 존재하지 않습니다."));
+                () -> new ApiRequestException("해당 댓글이 존재하지 않습니다."));
     }
 }


### PR DESCRIPTION
* 현재 요청 필터로 사용하고있는 `JwtAuthenticationFilter` 앞에 예외 처리를 위한 필터를 하나 추가했습니다.
* 요청을 필터링하던 도중 `JWT` 토큰에 문제가 있다면 `유효하지 않은 토큰` 오류 메시지를 응답으로 보내도록 수정했습니다.
 |__ 프론트에서는 메시지를 확인한 뒤 `유효하지 않은 토큰`의 메시지라면 로그인 페이지로 이동합니다.

< 예외처리 외 오류 수정 **`hotfix`** >
* 게시물 업데이트 오류 수정 (게시물 수정 시 삭제할 이미지 아이디 리스트(`rmImageIdList`)가 없는 경우 `NullPointerException` 발생)